### PR TITLE
Fix numpy "ModuleNotFoundError" and building wheels on Windows

### DIFF
--- a/native/PyPluginObject.cpp
+++ b/native/PyPluginObject.cpp
@@ -66,6 +66,12 @@ using namespace std;
 using namespace Vamp;
 using namespace Vamp::HostExt;
 
+#ifdef _WIN32
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
+
 static
 PyPluginObject *
 getPluginObject(PyObject *pyPluginHandle)

--- a/native/vampyhost.cpp
+++ b/native/vampyhost.cpp
@@ -68,6 +68,11 @@ using namespace std;
 using namespace Vamp;
 using namespace Vamp::HostExt;
 
+#ifdef _WIN32
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 static PyObject *
 list_plugins(PyObject *self, PyObject *)
 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython>=0.29", "numpy >= 1.15"]


### PR DESCRIPTION
This pull request should fix https://github.com/c4dm/vampy-host/issues/7 by adding a pyproject.toml with the necessary packages and also adds a Windows-specific typedef in the c++ code (this should not affect other systems). With both fixes the project can now be installed on Windows and the example in the README runs.