### PR TITLE
Add vamp-plugin-sdk as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vamp-plugin-sdk"]
+	path = vamp-plugin-sdk
+	url = https://github.com/c4dm/vamp-plugin-sdk.git


### PR DESCRIPTION
By adding the sdk as a submodule it is possible to install the package from git using `pip install git+<url>` and makes it easier for people who clone the repo.